### PR TITLE
Fix Codecov step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,13 @@ jobs:
       run: |
         pytest --cov=./ --cov-report=xml
     
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix CI to allow Codecov step failure

## Testing
- `pytest -q`
- `pytest --cov=./ --cov-report=xml -q`


------
https://chatgpt.com/codex/tasks/task_e_686d49ddf490832e83c61d6a4eadbd51